### PR TITLE
fix security group

### DIFF
--- a/app.tf
+++ b/app.tf
@@ -10,8 +10,8 @@ locals {
 
 locals {
   app_metadata = tomap({
-    // Inject app metadata into capabilities here (e.g. security_group_name, role_name)
-    role_name           = aws_iam_role.this.name
-    security_group_name = aws_security_group.this.name
+    // Inject app metadata into capabilities here (e.g. security_group_id, role_name)
+    role_name         = aws_iam_role.this.name
+    security_group_id = aws_security_group.this.id
   })
 }


### PR DESCRIPTION
All the app modules except for this one, output `security_group_id` in the app_metadata. I just changed this to match. I would assume that if we started attaching capabilities to this it would fail without being pass the `security_group_id`.